### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NZXT-cooler
-Python script to control NZXT cooler KrakenX52 in Linux
+Python script to control NZXT cooler KrakenX52/X62 in Linux
 
 ## Supported devices:
 
-- NZXT Kraken X52 (Vendor/Product ID: 0x1e71:0x170e)
+- NZXT Kraken X52/X62 (Vendor/Product ID: 0x1e71:0x170e)
 
 Note: It's possible that other devices are supported as well
 


### PR DESCRIPTION
The x62 is the same hardware with a 140mm radiator/fan vs the 120mm fan size on the x52. 
The USB device product ID for my x62 matches your X52.  `1e71:170e NZXT`  
The LED control works with my x62.