### PR TITLE
Feature: Automatic Fan and Pump speed control using lm_sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ but I could not verify that the flag works because I can't read fan and pump
 speed on my AMD B350 motherboard. If flags are not set, pump speed will have
 default value of 60% and fan speed 30%. 
 
+**Automatic fan and pumpcontrol**
+
+Use the flag --sensor-control to enable the automatic fan speed and pump speed.
+Please make sure the lm_sensors package is installed and configured.
+If you want to change the maximum allowed temprature use --max-safe-temp to change it. Default 80 degrees celcius.
+
 See also colctl --help
 
 Note: Solid and Solid All mode settings are not remembered after restart, I

--- a/bin/colctl
+++ b/bin/colctl
@@ -87,7 +87,13 @@ def main():
                         help="Speed between 60 and 100")
     parser.add_argument('-s', '--status', action='store_true', help="Print pump status, does not update if set.")
 
+    parser.add_argument('-sc', '--sensor_control', dest='sensor_control', action='store_true',
+                        help="Start automatic control deamon using lm_sensors")
 
+    parser.add_argument('-smt', '--safe-max-temp', dest='safe_max_temp', type=int, default=80,
+                        help="The maximum safe temprature for your cpu. Used for Sensor Cotrol deamon")
+
+    parser.set_defaults(sensor_control=False)
     args = parser.parse_args()
     varg = vars(args)
 

--- a/krakenx/color_change.py
+++ b/krakenx/color_change.py
@@ -196,12 +196,11 @@ class KrakenX52:
   def update(self):
     self._validate()
     self._send_color()
-    print(self._sensor_control)
     if not self._sensor_control:
       self._send_fan_speed()
       self._send_pump_speed()
       return self._receive_status()
     else:
-      print("Starting thread")
+      print("Starting thread...")
       self._start_sensor_thread()
 


### PR DESCRIPTION
I have been using the software for a few days now.
Sadly I miss automatic speed control of the pump and fans so i started work to incorporate it!

The above pull request uses the sensors executable to extract the current CPU temprature.
Based on it it calculates appropriate pump and fan speeds. Slowly increasing or decreasing the speed
of the Fans and Pump to the max 100 percent or the minimal of 60 for the pump.
I wanted to be sure that the fans also had a minimum speed which i set to 40 percent.

Feedback / Comments are appreciated!

P.S. The calculation for getting the fanspeed might be to low or overkill more experimentation is needed before i would call it safe. I have tested my cpu with mprime for 30 minutes and my CPU did not go over 47 degrees C but your mileage may very.