### PR TITLE
Pad all writes with zeros

### DIFF
--- a/krakenx/color_change.py
+++ b/krakenx/color_change.py
@@ -34,8 +34,9 @@ class KrakenX52:
         raise ValueError("colors must be tuples of 3 int between 0 and 255")
 
   @classmethod
-  def _flatten(cls, *args):
-    return list(itertools.chain(*args))
+  def _build_msg(cls, *args):
+    payload = list(itertools.chain(*args))
+    return payload + [0]*(65 - len(payload))
 
   @classmethod
   def _grb_color(cls, color):
@@ -87,27 +88,27 @@ class KrakenX52:
     return (self._mode.mode[0], self._aspeed)
 
   def _send_pump_speed(self):
-    self.dev.write(0x01, [0x02, 0x4d, 0x40, 0x00, self._pspeed])
+    self.dev.write(0x01, KrakenX52._build_msg([0x02, 0x4d, 0x40, 0x00, self._pspeed]))
 
   def _send_fan_speed(self):
-    self.dev.write(0x01, [0x02, 0x4d, 0x00, 0x00, self._fspeed])
+    self.dev.write(0x01, KrakenX52._build_msg([0x02, 0x4d, 0x00, 0x00, self._fspeed]))
 
   def _send_color(self):
     if self._mode==self.MODE_SOLID:
       color = self._colors[0]
-      self.dev.write(0x01, KrakenX52._flatten(
+      self.dev.write(0x01, KrakenX52._build_msg(
         [0x02, 0x4c, 0x00],
         self._mode_bytes(),
         self._grb_color(self._colors[0]),
         *itertools.repeat(color, 8)))
     elif self._mode==self.MODE_SOLID_ALL:
-      self.dev.write(0x01, KrakenX52._flatten(
+      self.dev.write(0x01, KrakenX52._build_msg(
         [0x02, 0x4c, 0x00],
         self._mode_bytes(),
         self._grb_color(self._text_color),
         *self._colors))
     elif self._mode==self.MODE_SPECTRUM_WAVE:
-      self.dev.write(0x01, KrakenX52._flatten(
+      self.dev.write(0x01, KrakenX52._build_msg(
         [0x02, 0x4c, 0x00],
         self._mode_speed(),
         *itertools.repeat(self.DEFAULT_COLOR, 9)))
@@ -121,7 +122,7 @@ class KrakenX52:
       self.MODE_SPINNER,
       self.MODE_CHASER]:
       for i in range(self._color_count):
-        self.dev.write(0x01, KrakenX52._flatten(
+        self.dev.write(0x01, KrakenX52._build_msg(
           [0x02, 0x4c, 0x00],
           self._mode_bytes(i),
           self._grb_color(self._text_color if self._text_color is not None else self._colors[i]),


### PR DESCRIPTION
TL;DR

The absence of padding made some of the messages sent to the device shorter than others.  This made the cooler appear unresponsive after the second run (see #10).

To fix this, this patch repurposes `_flatten` (renaming it to `_build_msg`) to both flatten and pad the messages, and applies it where it was missing.  The apparently magical value of 65 bytes is borrowed from my experience with liquidctl, and is the same for both Kraken and Smart Device.

---

The firmware on the device probably reads a fixed amount of bytes every time, just like we do.  What happens when that overflows will depend on the specific kernel and driver in use, as well as the firmware version.  Maybe in the past it implemented an internal buffer but was later simplified, because the developers felt the device did not need to handle these cases if CAM simply pad all messages.

As for the number of bytes to write, I specifically tested 65 and other (lower) values with the krakenx codebase: 32 (the maximum number of non-zero bytes sent), 33 (that plus one) and 64 (a more obvious choice), as well as null-terminated messages with no extra padding (which would not make sense, but could still be easily tested).

Partially for fun, I then ran the script bellow with an adapted `_build_msg`.  The "output" was, indeed, 65.

```python
import os
import subprocess
import time

env = os.environ.copy()
write_len = 70

while write_len >= 0:
    print('=> write_len={}'.format(write_len))
    env['WRITE_LENGTH'] = str(write_len)
    # use the ring leds to track whether this write_len worked or not:
    # run colctl twice, first re-rendering the previous write_len value, then
    # overwritting it with the current one to mark it as working
    for i in range(0, 2):
        args = ['colctl', '-m', 'solidall', '-fs', '80', '-ps', '80', '-cc', '8', '-c' '0,0,0']
        # "render" the last known good write_len on the ring, in binary;
        # not that easy to read (because of the infinity mirror), but works
        for j in range(0, 8):
            args += ['-c' + str(j), '255,0,64' if (write_len + 1 - i) & (1 << j) else '255,255,255']
        subprocess.run(args, env=env)
        time.sleep(1)
    write_len -= 1
```

```
  @classmethod
  def _build_msg(cls, *args):
    import os
    payload = list(itertools.chain(*args))
    return payload + [0]*(int(os.environ['WRITE_LENGTH']) - len(payload))
```