### PR TITLE
Add support for fan and pump speed profiles based on liquid temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,25 @@ Only use flag animation speed, if flag is not set it will have default value
 (0). Example:  
 `colctl --mode spectrumwave --animation_speed 3`
 
-Pump speed and fan speed are controled via `--pump_speed` and `--fan_speed` modes,
-but I could not verify that the flag works because I can't read fan and pump
-speed on my AMD B350 motherboard. If flags are not set, pump speed will have
-default value of 60% and fan speed 30%. 
+**Fan and pump speeds**
+
+Fan and pump speeds can be controled via the `--fan_speed` and `--pump_speed`
+options.  They are always set in duty percentages (multiplied by 100), and can
+either be fixed values (by passing a single integer number) or profiles
+depending on liquid temperatue (by passing multiple comma-separated
+`(<temperature>, <speed>)` tuples).
+
+```
+colctl --fan_speed 50 --pump_speed 60 [...]
+colctl --fan_speed "(20,30),(30,50),(40,90),(45,100)" [...]
+```
+
+If either flag is not set, a default profile will be applied in its place.
+
+---
 
 See also `colctl --help`
 
 Note: Solid and Solid All mode settings are not remembered after restart, I
 think that is due to the firmware bug.
+

--- a/bin/colctl
+++ b/bin/colctl
@@ -87,12 +87,13 @@ def main(parser):
 
     parser.add_argument('-as', '--animation_speed', dest='aspeed', type=int, default=0,
                         help="Speed between 0 and 4")
-   
-    parser.add_argument('-fs', '--fan_speed', dest='fspeed', type=int, default=30,
-                        help="Speed between 25 and 100")
 
-    parser.add_argument('-ps', '--pump_speed', dest='pspeed', type=int, default=60,
-                        help="Speed between 60 and 100")
+    parser.add_argument('-fs', '--fan_speed', dest='fspeed', default=[(20, 25), (30, 55), (36,75), (40, 85), (50, 100)],
+                        help="Fan speed between 25 and 100; fixed value or comma-separated (temperature,percentage) pairs")
+
+    parser.add_argument('-ps', '--pump_speed', dest='pspeed', default=[(30, 60), (36, 90), (40, 100)],
+                        help="Pump speed between 60 and 100; fixed value or comma-separated (temperature,percentage) pairs")
+
     parser.add_argument('-s', '--status', action='store_true', help="Print pump status, does not update if set.")
 
 

--- a/krakenx/color_change.py
+++ b/krakenx/color_change.py
@@ -3,9 +3,12 @@ from collections import namedtuple
 import sys
 import usb.core
 import itertools
+# import krakenx.profile
+from krakenx import profile
 
 VENDOR = 0x1e71
 PRODUCT = 0x170e
+CRITICAL_TEMP = 60
 
 class KrakenX52:
 
@@ -49,11 +52,9 @@ class KrakenX52:
     if self._aspeed < 0 or self._aspeed > 4 or not isinstance(self._aspeed, int):
       raise ValueError("Animation speed must be integer number between 0 and 4")
 
-    if self._fspeed < 25 or self._fspeed > 100 or not isinstance(self._fspeed, int):
-      raise ValueError("Fan speed must be integer number between 25 and 100")
+    self._fspeed = profile.parse(self._fspeed, 25, 100, CRITICAL_TEMP - 1)
 
-    if self._pspeed < 60 or self._pspeed > 100 or not isinstance(self._pspeed, int):
-      raise ValueError("Pump speed must be integer number between 60 and 100")
+    self._pspeed = profile.parse(self._pspeed, 60, 100, CRITICAL_TEMP - 1)
 
     self._check_color(self._text_color)
 
@@ -76,9 +77,9 @@ class KrakenX52:
 
     self._aspeed = kwargs.pop('aspeed', 0)
 
-    self._fspeed = kwargs.pop('fspeed', 30)
+    self._fspeed = kwargs.pop('fspeed')
 
-    self._pspeed = kwargs.pop('pspeed', 60)
+    self._pspeed = kwargs.pop('pspeed')
 
   def _mode_bytes(self, i=0):
     # set the higher 3 bits of the 2rd byte to denote the number of colors being set
@@ -87,11 +88,20 @@ class KrakenX52:
   def _mode_speed(self):
     return (self._mode.mode[0], self._aspeed)
 
+  def _generic_speed(self, channel, speed):
+    # krakens currently require the same set of temperatures on both channels
+    stdtemps = range(20, 62, 2)
+    tmp = profile.normalize(speed, CRITICAL_TEMP)
+    norm = [(t, profile.interpolate(tmp, t)) for t in stdtemps]
+    cbase = {'fan': 0x80, 'pump': 0xc0}[channel]
+    for i, (temp, duty) in enumerate(norm):
+      self.dev.write(0x01, KrakenX52._build_msg([0x02, 0x4d, cbase + i, temp, duty]))
+
   def _send_pump_speed(self):
-    self.dev.write(0x01, KrakenX52._build_msg([0x02, 0x4d, 0x40, 0x00, self._pspeed]))
+    self._generic_speed('pump', self._pspeed)
 
   def _send_fan_speed(self):
-    self.dev.write(0x01, KrakenX52._build_msg([0x02, 0x4d, 0x00, 0x00, self._fspeed]))
+    self._generic_speed('fan', self._fspeed)
 
   def _send_color(self):
     if self._mode==self.MODE_SOLID:

--- a/krakenx/profile.py
+++ b/krakenx/profile.py
@@ -1,0 +1,119 @@
+from ast import literal_eval
+
+def parse(arg, minduty, maxduty, maxtemp):
+  """Parse and validate duty profiles or fixed values.
+
+  >>> parse('(20,30),(30,50),(34,80),(40,90),(50,100)', 25, 100, 59)
+  [(20, 30), (30, 50), (34, 80), (40, 90), (50, 100)]
+  >>> parse('35', 25, 100, 59)
+  [(0, 35), (59, 35)]
+
+  Because of how Kraken52 initializes and validates values in different places,
+  this function can be called with already parsed profiles; in those cases,
+  only validation is perfomed.
+
+  >>> parse([(20, 30), (50, 100)], 25, 100, 59)
+  [(20, 30), (50, 100)]
+  >>> parse([(0, 35), (59, 35)], 25, 100, 59)
+  [(0, 35), (59, 35)]
+
+  The profile is validated in structure and acceptable ranges.  Duty is checked
+  against `minduty`  and `maxduty`.  Liquid temperature must be between 0°C and
+  `maxtemp`.
+
+  >>> parse('(20,30),(50,100', 25, 100, 59)
+  Traceback (most recent call last):
+    ...
+  ValueError: Profile must be comma-separated (temperature, duty) tuples
+  >>> parse('(20,30),(50,100,2)', 25, 100, 59)
+  Traceback (most recent call last):
+    ...
+  ValueError: Profile must be comma-separated (temperature, duty) tuples
+  >>> parse('(20,30),(50,97.6)', 25, 100, 59)
+  Traceback (most recent call last):
+    ...
+  ValueError: Duty must be integer number between 25 and 100
+  >>> parse('(20,15),(50,100)', 25, 100, 59)
+  Traceback (most recent call last):
+    ...
+  ValueError: Duty must be integer number between 25 and 100
+  >>> parse('(20,30),(70,100)', 25, 100, 59)
+  Traceback (most recent call last):
+    ...
+  ValueError: Liquid temperature must be integer number between 0 and 59
+  """
+  generror = ValueError("Profile must be comma-separated (temperature, duty) tuples")
+  if isinstance(arg, str):
+    try:
+      val = literal_eval('[' + arg + ']')
+      if len(val) == 1 and isinstance(val[0], int):
+        # for arg == '<number>' set fixed duty between 0 and 59 °C
+        val = [(0, val[0]), (59, val[0])]
+    except:
+      raise generror
+  elif isinstance(arg, int):
+    val = [(0, arg), (59, arg)]
+  elif isinstance(arg, list):
+    val = arg
+  else:
+    raise generror
+  for step in val:
+    if not isinstance(step, tuple) or len(step) != 2:
+      raise generror
+    temp, duty = step
+    if not isinstance(temp, int) or temp < 0 or temp > maxtemp:
+      raise ValueError("Liquid temperature must be integer number between 0 and {}".format(maxtemp))
+    if not isinstance(duty, int) or duty < minduty or duty > maxduty:
+      raise ValueError('Duty must be integer number between {} and {}'.format(minduty, maxduty))
+  return val
+
+def normalize(profile, critx):
+  """Normalize a [(x:int, y:int), ...] profile.
+
+  The normalized profile will ensure that:
+
+   - the profile is a monotonically increasing function
+     (i.e. for every i, i > 1, x[i] - x[i-1] > 0 and y[i] - y[i-1] >= 0)
+   - the profile is sorted
+   - a (critx, 100) failsafe is enforced
+
+  >>> normalize([(30, 40), (25, 25), (35, 30), (40, 35), (40, 80)], 60)
+  [(25, 25), (30, 40), (35, 40), (40, 80), (60, 100)]
+  """
+  profile = sorted(list(profile) + [(critx, 100)], key=lambda p: (p[0], -p[1]))
+  mono = profile[0:1]
+  for (x, y), (xb, yb) in zip(profile[1:], profile[:-1]):
+    if x == xb:
+      continue
+    if y < yb:
+      y = yb
+    mono.append((x, y))
+  return mono
+
+def interpolate(profile, x):
+  """Interpolate y given x and a [(x: int, y: int), ...] profile.
+
+  Requires the profile to be sorted by x, with no duplicate x values (see
+  normalize).  Expects profiles with integer x and y values, and
+  returns duty rounded to the nearest integer.
+
+  >>> interpolate([(20, 50), (50, 70), (60, 100)], 33)
+  59
+  >>> interpolate([(20, 50), (50, 70)], 19)
+  50
+  >>> interpolate([(20, 50), (50, 70)], 51)
+  70
+  >>> interpolate([(20, 50)], 20)
+  50
+  """
+  lower, upper = profile[0], profile[-1]
+  for step in profile:
+    if step[0] <= x:
+      lower = step
+    if step[0] >= x:
+      upper = step
+      break
+  if lower[0] == upper[0]:
+    return lower[1]
+  return round(lower[1] + (x - lower[0])/(upper[0] - lower[0])*(upper[1] - lower[1]))
+


### PR DESCRIPTION
Profiles are automatically validated, normalized and interpolated between 20°C and 60°C, in 2°C steps.
For why this is necessary, check the discussion in #11 (in particular [this comment](https://github.com/KsenijaS/krakenx/issues/11#issuecomment-416070614)).

Apart from parsing and validation code, the protocol implementation is, essentially, a port from the relevant parts of [liquidctl](https://github.com/jonasmalacofilho/liquidctl/blob/master/liquidctl/driver/kraken_two.py).

---

The syntax extends the `--fan_speed` and `--pump_speed` options (and their shorthands `-fs` and `-ps`)  to accept comma-separated lists of tuples:

```
# colctl --fan_speed 50 --pump_speed 60 [...]
# colctl --fan_speed "(20,30),(30,50),(40,90),(45,100)" [...]
```

I am not sure about these parentheses though.  While they improve readability (compared with what I did for liquidctl), it is somewhat annoying that they need to quoted or escaped in Linux/Unix shells (not sure about Command Prompt/Power Shell).  What do you think?

---

The default profiles are adaptions of what I use on my Kraken X62.  But since I had to rely on my notes to convert the noise levels and performance from the NF-A14s I currently use to the stock Aer P 140s, they might be a bit off.

The goal was to provide sane defaults, that would stay within acceptable noise levels while still being more aggressive than CAM's (not at all) 'performance' profile.  Can some of you test if what I am proposing achieves that?

For reference, these are CAM's base profiles, if my notes are to be trusted:

```
$ echo silent
# colctl -fs '(35,25),(40,35),(45,45),(50,55),(55,75)' -ps '(35,60),(40,70),(45,80),(50,90),(55,100)'

$ echo performance
# colctl -fs '(35,50),(40,60),(45,70),(50,80),(55,90)' -ps '(35,70),(40,80),(45,85),(50,90),(55,95)'
```

Note: we cannot forget about the smaller X52 and, even, the tiny X42.