### PR TITLE
Instantiate the driver with its find_supported_devices class method

### DIFF
--- a/bin/colctl
+++ b/bin/colctl
@@ -91,11 +91,8 @@ def main(parser):
 
     args = parser.parse_args()
     varg = vars(args)
-    
-    devices = list(usb.core.find(idVendor=VENDOR, idProduct=PRODUCT, find_all=True))
 
-    for dev in devices:
-      cooler = KrakenX52(dev, **varg)
+    for cooler in KrakenX52.find_supported_devices(**varg):
       cooler.connect()
       try:
         if args.status:

--- a/krakenx/color_change.py
+++ b/krakenx/color_change.py
@@ -62,8 +62,8 @@ class KrakenX52(KrakenTwoDriver):
     for j in range(self._color_count):
       self._check_color(self._colors[j])
 
-  def __init__(self, dev, **kwargs):
-    super(KrakenX52, self).__init__(dev, 'NZXT Kraken X42/X52/X62/X72')
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
     self._mode = kwargs.pop('mode', self.MODE_SOLID)
     self._color_channel = kwargs.pop('color_channel')
     self._text_color = kwargs.pop('text_color', self.DEFAULT_COLOR)
@@ -74,7 +74,6 @@ class KrakenX52(KrakenTwoDriver):
     self._aspeed = kwargs.pop('aspeed', 0)
     self._fspeed = kwargs.pop('fspeed')
     self._pspeed = kwargs.pop('pspeed')
-    self.dev = dev
 
   def _send_pump_speed(self):
     self.set_speed_profile('pump', self._pspeed)

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ setup(
     version='0.0.3',
     packages=['krakenx'],
     scripts=['bin/colctl', 'bin/colctl.py'],
-    install_requires=['pyusb', 'liquidctl>=1.1.0'],
+    install_requires=['pyusb', 'liquidctl>=1.2.0'],
 )


### PR DESCRIPTION
Prevents "deprecated: delegate to find_supported_devices or use an appropriate wrapper" warnings with liquidctl >= 1.2.0.